### PR TITLE
fix build & have copy-paste ready code at slides

### DIFF
--- a/data-script.R
+++ b/data-script.R
@@ -43,7 +43,11 @@ if (!(file.exists ("data/dodgr-flows-ms.Rds") &
     index <- grep ("promenade", ms$osm_lines$name, ignore.case = TRUE)
     kp <- grep ("kanal", ms$osm_lines$name, ignore.case = TRUE)
     index <- index [!index %in% kp]
+    # this should work, too, and it's a bit shorter
+    # (note the capital 'P' and 'ignore.case = FALSE')
+    # index <- grep ("Promenade", ms$osm_lines$name, ignore.case = FALSE)
     ids <- ms$osm_lines$osm_id [index] %>% as.character ()
+    g <- weight_streetnet (ms$osm_lines, wt_profile = "bicycle")
     index <- which (g$way_id %in% ids)
 
     g0 <- weight_streetnet (ms$osm_lines, wt_profile = "bicycle")
@@ -78,7 +82,7 @@ if (!(file.exists ("data/dodgr-flows-ms.Rds") &
 
     if (!file.exists ("data/dodgr-flows-ms70.Rds"))
     {
-        message ("Aggregating flows with promenade = 80%")
+        message ("Aggregating flows with promenade = 70%")
         g <- g0
         g$d_weighted [index] <- g$d [index] * 0.7
         f <- dodgr_flows_aggregate (g, from = pts, to = pts, flows = flowmat)

--- a/ms-meetup-nov18.Rmd
+++ b/ms-meetup-nov18.Rmd
@@ -429,7 +429,7 @@ How to visualise just the Promenade?
 library (osmdata)
 promenade <- opq ("münster de") %>%
     add_osm_feature (key = "highway") %>%
-    add_osm_feature (key = "name", value = "promenade", #<<
+    add_osm_feature (key = "name", value = "Promenade", #<<
                      value_exact = FALSE) %>%           #<<
     osmdata_sf ()
 ```
@@ -445,7 +445,7 @@ How to visualise just the Promenade?
 library (osmdata)
 promenade <- opq ("münster de") %>%
     add_osm_feature (key = "highway") %>%
-    add_osm_feature (key = "name", value = "promenade",
+    add_osm_feature (key = "name", value = "Promenade",
                      value_exact = FALSE) %>%
     osmdata_sf ()
 library (mapview)

--- a/ms-meetup-nov18.Rmd
+++ b/ms-meetup-nov18.Rmd
@@ -951,10 +951,10 @@ mapdeck <br> time!<br>
 library (mapdeck)
 fm$flow <- 20 * fm$flow / max (fm$flow)
 pal <- colorRampPalette (c ("lawngreen", "red"))
-loc <- as.numeric(apply (sf::st_coordinates (ms$osm_lines), 2, mean)) [1:2]
+loc <- apply (sf::st_coordinates (ms$osm_lines), 2, mean) [1:2]
 mapdeck (style = 'mapbox://styles/mapbox/dark-v9',
          zoom = 12,
-         location = loc) %>%
+         location = as.numeric(loc)) %>%
     add_line (data = fm,
               layer_id = "ms-highways",
               origin = c("from_lon", "from_lat"),
@@ -1018,8 +1018,9 @@ shorter <- 0.1
 g <- weight_streetnet (ms$osm_lines, wt_profile = "bicycle")
 index <- which (g$way_id %in% ids_prom)
 g$d_weighted [index] <- g$d [index] * (1 - shorter) #<<
+flow_mat <- matrix (1, nrow = 1000, ncol = 1000)
 f <- dodgr_flows_aggregate (g, from = pts, to = pts,
-                            flows = flowmat)
+                            flows = flow_mat)
 ```
 
 ---

--- a/ms-meetup-nov18.Rmd
+++ b/ms-meetup-nov18.Rmd
@@ -511,7 +511,7 @@ mapview (ms48155$osm_lines) %>%
 ```{r promenade-data4, eval = FALSE}
 promenade <- opq ("münster de") %>%
     add_osm_feature (key = "highway") %>%
-    add_osm_feature (key = "name", value = "promenade",
+    add_osm_feature (key = "name", value = "Promenade",
                      value_exact = FALSE) %>%
     osmdata_sf ()
 ```
@@ -949,9 +949,9 @@ mapdeck <br> time!<br>
 
 ```{r ms-mapdeck, eval = FALSE}
 library (mapdeck)
-f$flow <- 20 * f$flow / max (f$flow)
+fm$flow <- 20 * fm$flow / max (fm$flow)
 pal <- colorRampPalette (c ("lawngreen", "red"))
-loc <- apply (sf::st_coordinates (ms$osm_lines), 2, mean) [1:2]
+loc <- as.numeric(apply (sf::st_coordinates (ms$osm_lines), 2, mean)) [1:2]
 mapdeck (style = 'mapbox://styles/mapbox/dark-v9',
          zoom = 12,
          location = loc) %>%
@@ -1042,8 +1042,9 @@ shorter <- 0.1
 g <- weight_streetnet (ms$osm_lines, wt_profile = "bicycle")
 index <- which (g$way_id %in% ids_prom)
 g$d_weighted [index] <- g$d [index] * (1 - shorter)
+flow_mat <- matrix (1, nrow = 1000, ncol = 1000)
 f <- dodgr_flows_aggregate (g, from = pts, to = pts,
-                            flows = flowmat)
+                            flows = flow_mat)
 ```
 
 ---
@@ -1135,7 +1136,7 @@ class: center, middle, inverse
 
 ---
 
-# Where is Münster are cyclists most exposed to air pollution?
+# Where in Münster are cyclists most exposed to air pollution?
 
 - Air pollution comes from automotive vehicles, so need to know where they
   travel


### PR DESCRIPTION
Running `make` complained about a missing variable (the streetnet weighted for bicycles). I copied the corresponding code from the slides and now `make` runs through (apart from to-be-installed R packages).
Furthermore, I adapted the source code on the slides at some places such that it is copy-paste ready (i.e., throws no errors).